### PR TITLE
Add linebreak between day, night forecasts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "platinumdx-weather-card",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "platinumdx-weather-card",
   "keywords": [
     "home-assistant",

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,1 +1,1 @@
-export const CARD_VERSION = '1.0.15';
+export const CARD_VERSION = '1.0.16';

--- a/src/platinumdx-weather-card.ts
+++ b/src/platinumdx-weather-card.ts
@@ -859,7 +859,7 @@ export class PlatinumdxWeatherCard extends LitElement {
         return nightForecast['temperature'] !== undefined ? String(nightForecast['temperature']) : undefined;
       }
       else if (propKey === 'detailed_description') {
-        return (dayForecast[propKey] !== undefined ? String(dayForecast[propKey]) : "") + (nightForecast[propKey] !== undefined ? String(nightForecast[propKey]) : "")
+        return (dayForecast[propKey] !== undefined ? String(dayForecast[propKey]) : "") + "\n" + (nightForecast[propKey] !== undefined ? String(nightForecast[propKey]) : "")
       }
       return dayForecast[propKey] !== undefined ? String(dayForecast[propKey]) : undefined;
     }


### PR DESCRIPTION
Attempting to clean up the day/night sections where a mouseover shows both the day and night forecast descriptions.  This should add a linebreak between them.