### PR TITLE
Fix error - Include today and full number of days

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -1,1 +1,1 @@
-export const CARD_VERSION = '1.0.17';
+export const CARD_VERSION = '1.0.18';

--- a/src/platinumdx-weather-card.ts
+++ b/src/platinumdx-weather-card.ts
@@ -541,7 +541,8 @@ export class PlatinumdxWeatherCard extends LitElement {
     const htmlDays: TemplateResult[] = [];
     const days = this._config.daily_forecast_days || 5;
 
-    for (var i = 0; i < days; i++) {
+    for (var i = 0; i < days + 1; i++) {
+      //added +1 to days to make sure that today AND the full number of days selected are shown.
       const forecastDate = new Date();
       forecastDate.setDate(forecastDate.getDate() + i);
       //deleted +1 after +i to try and include today in forecast display.


### PR DESCRIPTION
Today was included properly with 1.0.17.  But it stopped the loop too early so I didn't get the full 7 days.  This should fix that.